### PR TITLE
Fixed compililation errors for Linux >4.6.4.

### DIFF
--- a/isgx.h
+++ b/isgx.h
@@ -22,6 +22,7 @@
 #include <linux/rwsem.h>
 #include <linux/sched.h>
 #include <linux/workqueue.h>
+#include <linux/version.h>
 
 /* Number of times to spin before going to sleep because of an interrupt
  * storm.

--- a/isgx_util.c
+++ b/isgx_util.c
@@ -100,7 +100,12 @@ struct page *isgx_get_backing_page(struct isgx_enclave* enclave,
 
 	backing_addr = enclave->backing + entry->addr - enclave->base;
 
-	ret = get_user_pages(enclave->owner,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,4)
+	ret = get_user_pages_remote(
+#else
+	ret = get_user_pages(
+#endif
+			     enclave->owner,
 			     enclave->mm,
 			     backing_addr,
 			     1, /* nr_pages */


### PR DESCRIPTION
Deprecated `get_user_pages` backwards compatibility macros have been removed from Linux v4.6.4 onwards (see Linux kernel commit [#c12d2da](https://github.com/torvalds/linux/commit/c12d2da)).
