### PR TITLE
Added .gitignore and Makefile install target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.ko
+*.o
+*.cmd
+*.mod.*
+*.symvers
+*.order
+*.tmp_versions

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ PWD  := $(shell pwd)
 
 default:
 	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) CFLAGS_MODULE="-DDEBUG -g -O0" modules
+
+install: default
+	$(MAKE) INSTALL_MOD_DIR=kernel/drivers/intel/sgx -C $(KDIR) M=$(PWD) modules_install
+	sh -c "cat /etc/modules | grep -Fxq isgx || echo isgx >> /etc/modules"
+
 endif
 
 clean:

--- a/README.md
+++ b/README.md
@@ -44,13 +44,9 @@ $ make
 You can find the driver *isgx.ko* generated in the same directory.
 
 ###Install the Intel(R) SGX Driver
-To install the Intel SGX driver, enter the following commands: 
+To install the Intel SGX driver, enter the following command with root privilege:
 ```
-$ sudo mkdir -p "/lib/modules/"`uname -r`"/kernel/drivers/intel/sgx"
-$ sudo cp isgx.ko "/lib/modules/"`uname -r`"/kernel/drivers/intel/sgx"
-$ sudo sh -c "cat /etc/modules | grep -Fxq isgx || echo isgx >> /etc/modules"
-$ sudo /sbin/depmod
-$ sudo /sbin/modprobe isgx
+$ sudo make install
 ```
 
 ###Uninstall the Intel(R) SGX Driver


### PR DESCRIPTION
`make install` simplifies the existing installation procedure outlined in the README.

Note that external modules are by default installed in `/lib/modules/$(KERNELRELEASE)/extra/` (cf. section 5 of https://www.kernel.org/doc/Documentation/kbuild/modules.txt).  I used `INSTALL_MOD_DIR` to make sure the isgx driver is installed in `/lib/modules/$(KERNELRELEASE)/kernel/drivers/intel/sgx`.
