### PR TITLE
Support DKMS

### DIFF
--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+VERSION=0.10
+MODULE_DIR="/usr/src/isgx-$VERSION"
+
+mkdir -p "$MODULE_DIR/src"
+cp -r * "$MODULE_DIR/src"
+mv "$MODULE_DIR/src/dkms.conf" "$MODULE_DIR/"
+cat Makefile | sed "s/KERNELRELEASE/PATCHLEVEL/g" > "$MODULE_DIR/src/Makefile"
+dkms add -m isgx -v "$VERSION"
+dkms build -m isgx -v "$VERSION" --verbose
+dkms install -m isgx -v "$VERSION"

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,8 @@
+MAKE="make -C src/ KERNELDIR=/lib/modules/${kernelver}/build"
+CLEAN="make -C src/ clean"
+BUILT_MODULE_NAME=isgx
+BUILT_MODULE_LOCATION=src/
+PACKAGE_NAME=isgx
+PACKAGE_VERSION=0.10
+REMAKE_INITRD=yes
+DEST_MODULE_LOCATION=/updates


### PR DESCRIPTION
Standard "make install" fails in Ubuntu 16.04 because kernel there requires signed modules.

DKMS cares about all of that.
