### PR TITLE
Update readme for driver installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ You can find the driver *isgx.ko* generated in the same directory.
 ###Install the Intel(R) SGX Driver
 To install the Intel SGX driver, enter the following command with root privilege:
 ```
-$ sudo make install
+$ sudo mkdir -p "/lib/modules/"`uname -r`"/kernel/drivers/intel/sgx"    
+$ sudo cp isgx.ko "/lib/modules/"`uname -r`"/kernel/drivers/intel/sgx"    
+$ sudo sh -c "cat /etc/modules | grep -Fxq isgx || echo isgx >> /etc/modules"    
 ```
-Note you may see an error complaining "Can't read private key" or similar message. This just means that you don't have access to Ubuntu signing key. The driver should still be installed to /lib/modules/$(KERNELRELEASE)/kernel/drivers/intel/sgx.
 
 ### Load the Intel(R) SGX Driver
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,6 @@ To install the Intel SGX driver, enter the following command with root privilege
 $ sudo mkdir -p "/lib/modules/"`uname -r`"/kernel/drivers/intel/sgx"    
 $ sudo cp isgx.ko "/lib/modules/"`uname -r`"/kernel/drivers/intel/sgx"    
 $ sudo sh -c "cat /etc/modules | grep -Fxq isgx || echo isgx >> /etc/modules"    
-```
-
-### Load the Intel(R) SGX Driver
-
-```
 $ sudo /sbin/depmod
 $ sudo /sbin/modprobe isgx
 ```


### PR DESCRIPTION
Update README instruction for how to install driver.
Since the previous check-in to support "make install" doesn't work for unbuntu 14.04
And according to Yuan, the last two commands listed in "Load Driver" section must be run to enable the driver so that we could merge them into "Install Driver" section too.

Signed-off-by: Zhao Hui Du zhao.hui.du@intel.com
