### PR TITLE
Fix implicit declaration for 'fput' error in old kernel

### DIFF
--- a/isgx_util.c
+++ b/isgx_util.c
@@ -16,6 +16,7 @@
 #include "isgx.h"
 #include <linux/highmem.h>
 #include <linux/shmem_fs.h>
+#include <linux/file.h>
 
 void *isgx_get_epc_page(struct isgx_epc_page *entry)
 {


### PR DESCRIPTION
 Signed-off-by: lzha101 lili.z.zhang@intel.com

The error is found on system with kernel version 3.10.xxx. 
