### PR TITLE
Fix signed integer overflow on shift

### DIFF
--- a/isgx_ioctl.c
+++ b/isgx_ioctl.c
@@ -237,7 +237,7 @@ static int validate_secs(const struct isgx_secs *secs)
 
 	for (i = 2; i < 64; i++) {
 		tmp = isgx_ssaframesize_tbl[i];
-		if (((1 << i) & secs->xfrm) && (tmp > needed_ssaframesize))
+		if (((1UL << i) & secs->xfrm) && (tmp > needed_ssaframesize))
 			needed_ssaframesize = tmp;
 	}
 


### PR DESCRIPTION
shifting a signed integer value of 1 by 31 or more bits will cause
overflow and can lead to undefined behaviour.  Fix this by adding
a UL suffix to ensure an unsigned long is being shifted.

Signed-off-by: Colin Ian King <colin.king@canonical.com>