### PR TITLE
Removing BUG_ON macro call on isgx_eremove() failure

### DIFF
--- a/isgx_page_cache.c
+++ b/isgx_page_cache.c
@@ -479,7 +479,7 @@ void isgx_free_epc_page(struct isgx_epc_page *entry,
 	}
 
 	if (flags & ISGX_FREE_EREMOVE)
-		BUG_ON(isgx_eremove(entry));
+		isgx_eremove(entry);
 
 	spin_lock(&isgx_free_list_lock);
 	list_add(&entry->free_list, &isgx_free_list);

--- a/isgx_util.c
+++ b/isgx_util.c
@@ -84,7 +84,7 @@ int isgx_eremove(struct isgx_epc_page *epc_page)
 	isgx_put_epc_page(epc);
 
 	if (ret)
-		pr_debug_ratelimited("EREMOVE returned %d\n", ret);
+		pr_err("EREMOVE returned %d\n", ret);
 
 	return ret;
 }


### PR DESCRIPTION
When an enclave is removed in parallel with an enclave call then
isgx_eremove fails. The BUG_ON macro caused the application to freeze,
never letting the owning process to be closed.

Signed-off-by: Serge Ayoun <serge.ayoun@intel.com>