### PR TITLE
Enabling the release of EPC pages from suspended enclaves

### DIFF
--- a/isgx.h
+++ b/isgx.h
@@ -194,7 +194,7 @@ struct isgx_vma *isgx_find_vma(struct isgx_enclave *enclave,
 			       unsigned long addr);
 void isgx_zap_tcs_ptes(struct isgx_enclave *enclave,
 		       struct vm_area_struct *vma);
-bool isgx_pin_mm(struct isgx_enclave *encl);
+bool isgx_pin_mm(struct isgx_enclave *encl, bool pin_suspend);
 void isgx_unpin_mm(struct isgx_enclave *encl);
 void isgx_invalidate(struct isgx_enclave *encl);
 int isgx_find_enclave(struct mm_struct *mm, unsigned long addr,

--- a/isgx_ioctl.c
+++ b/isgx_ioctl.c
@@ -787,7 +787,7 @@ static bool process_add_page_req(struct isgx_add_page_req *req)
 	if (IS_ERR(epc_page))
 		return false;
 
-	if (!isgx_pin_mm(enclave)) {
+	if (!isgx_pin_mm(enclave, false)) {
 		isgx_free_epc_page(epc_page, enclave, 0);
 		return false;
 	}

--- a/isgx_page_cache.c
+++ b/isgx_page_cache.c
@@ -108,7 +108,7 @@ static struct isgx_enclave *isolate_cluster(struct list_head *dst,
 	if (!enclave)
 		return NULL;
 
-	if (!isgx_pin_mm(enclave)) {
+	if (!isgx_pin_mm(enclave, true)) {
 		kref_put(&enclave->refcount, isgx_enclave_release);
 		return NULL;
 	}
@@ -203,7 +203,7 @@ static void evict_cluster(struct isgx_enclave *enclave, struct list_head *src)
 	if (list_empty(src))
 		return;
 
-	if (!isgx_pin_mm(enclave)) {
+	if (!isgx_pin_mm(enclave, false)) {
 		while (!list_empty(src)) {
 			entry = list_first_entry(src, struct isgx_enclave_page,
 						 load_list);


### PR DESCRIPTION
After resuming from Si sleep state, suspended enclaves could
not be selected for eviction process. This could cause the EPC
to be locked and prevent any further page allocation.
Code was fixed to free those pages on a as needed base.

Signed-off-by: Serge Ayoun <serge.ayoun@intel.com>