### PR TITLE
For older versions of Linux kernel, fput() prototype is located

### DIFF
--- a/sgx_util.c
+++ b/sgx_util.c
@@ -66,6 +66,7 @@
 #else
 	#include <linux/signal.h>
 #endif
+#include "linux/file.h"
 
 struct page *sgx_get_backing(struct sgx_encl *encl,
 			     struct sgx_encl_page *entry,


### PR DESCRIPTION
in linux/file.h.
Adding this include file to sgx_util.c

Signed-off-by: Serge Ayoun <serge.ayoun@intel.com>