### PR TITLE
intel_sgx: Fix max enclave size calculation

### DIFF
--- a/sgx_main.c
+++ b/sgx_main.c
@@ -202,9 +202,9 @@ static int sgx_init_platform(void)
 	cpuid_count(SGX_CPUID, 0x0, &eax, &ebx, &ecx, &edx);
 	if (edx & 0xFFFF) {
 #ifdef CONFIG_X86_64
-		sgx_encl_size_max_64 = 1ULL << (edx & 0xFF);
+		sgx_encl_size_max_64 = 1ULL << ((edx >> 8) & 0xFF);
 #endif
-		sgx_encl_size_max_32 = 1ULL << ((edx >> 8) & 0xFF);
+		sgx_encl_size_max_32 = 1ULL << (edx & 0xFF);
 	}
 
 	sgx_nr_epc_banks = 0;


### PR DESCRIPTION
sgx_encl_size_max_64 and sgx_encl_size_max_32 calculations are
incorrect, causing failures creating large enclaves.
2^EDX[7:0] should be used for max enclave size in 32-bit mode
2^EDX[15:8] should be used for max enclave size in 64-bit mode

Signed-off-by: Angie Chinchilla <angie.v.chinchilla@intel.com>