### PR TITLE
When loading a big enclave(e.g. 48G), VA pages occupy too much EPC pa…

### DIFF
--- a/sgx.h
+++ b/sgx.h
@@ -226,7 +226,7 @@ enum sgx_alloc_flags {
 int ksgxswapd(void *p);
 int sgx_page_cache_init(resource_size_t start, unsigned long size);
 void sgx_page_cache_teardown(void);
-struct sgx_epc_page *sgx_alloc_page(unsigned int flags);
+struct sgx_epc_page *sgx_alloc_page(struct sgx_encl *encl, unsigned int flags);
 int sgx_free_page(struct sgx_epc_page *entry, struct sgx_encl *encl);
 void *sgx_get_page(struct sgx_epc_page *entry);
 void sgx_put_page(void *epc_page_vaddr);

--- a/sgx_arch.h
+++ b/sgx_arch.h
@@ -346,7 +346,7 @@ struct sgx_epc_page {
 	struct list_head free_list;
 };
 
-extern struct sgx_epc_page *sgx_alloc_page(unsigned int flags);
+extern struct sgx_epc_page *sgx_alloc_page(struct sgx_encl *encl, unsigned int flags);
 extern int sgx_free_page(struct sgx_epc_page *entry, struct sgx_encl *encl);
 extern void *sgx_get_page(struct sgx_epc_page *entry);
 extern void sgx_put_page(void *epc_page_vaddr);

--- a/sgx_ioctl.c
+++ b/sgx_ioctl.c
@@ -224,7 +224,7 @@ static bool sgx_process_add_page_req(struct sgx_add_page_req *req)
 	struct vm_area_struct *vma;
 	int ret;
 
-	epc_page = sgx_alloc_page(0);
+	epc_page = sgx_alloc_page(encl, 0);
 	if (IS_ERR(epc_page))
 		return false;
 
@@ -409,7 +409,7 @@ static int sgx_init_page(struct sgx_encl *encl,
 		if (!va_page)
 			return -ENOMEM;
 
-		epc_page = sgx_alloc_page(0);
+		epc_page = sgx_alloc_page(encl, 0);
 		if (IS_ERR(epc_page)) {
 			kfree(va_page);
 			return PTR_ERR(epc_page);
@@ -542,7 +542,7 @@ static long sgx_ioc_enclave_create(struct file *filep, unsigned int cmd,
 	encl->backing = backing;
 	encl->pcmd = pcmd;
 
-	secs_epc = sgx_alloc_page(0);
+	secs_epc = sgx_alloc_page(NULL,0);
 	if (IS_ERR(secs_epc)) {
 		ret = PTR_ERR(secs_epc);
 		secs_epc = NULL;

--- a/sgx_page_cache.c
+++ b/sgx_page_cache.c
@@ -501,7 +501,7 @@ static struct sgx_epc_page *sgx_alloc_page_fast(void)
  *
  * Return: an EPC page or a system error code
  */
-struct sgx_epc_page *sgx_alloc_page(unsigned int flags)
+struct sgx_epc_page *sgx_alloc_page(struct sgx_encl *encl, unsigned int flags)
 {
 	struct sgx_epc_page *entry;
 
@@ -513,6 +513,13 @@ struct sgx_epc_page *sgx_alloc_page(unsigned int flags)
 		if (flags & SGX_ALLOC_ATOMIC) {
 			entry = ERR_PTR(-EBUSY);
 			break;
+		}
+
+		if (encl) {
+			if (encl->flags & SGX_ENCL_DEAD) {
+				entry = ERR_PTR(-ENOMEM);
+				break;
+			}
 		}
 
 		if (signal_pending(current)) {

--- a/sgx_util.c
+++ b/sgx_util.c
@@ -301,7 +301,7 @@ static struct sgx_encl_page *sgx_do_fault(struct vm_area_struct *vma,
 		goto out;
 	}
 
-	epc_page = sgx_alloc_page(SGX_ALLOC_ATOMIC);
+	epc_page = sgx_alloc_page(encl, SGX_ALLOC_ATOMIC);
 	if (IS_ERR(epc_page)) {
 		rc = PTR_ERR(epc_page);
 		epc_page = NULL;
@@ -310,7 +310,7 @@ static struct sgx_encl_page *sgx_do_fault(struct vm_area_struct *vma,
 
 	/* If SECS is evicted then reload it first */
 	if (encl->flags & SGX_ENCL_SECS_EVICTED) {
-		secs_epc_page = sgx_alloc_page(SGX_ALLOC_ATOMIC);
+		secs_epc_page = sgx_alloc_page(encl, SGX_ALLOC_ATOMIC);
 		if (IS_ERR(secs_epc_page)) {
 			rc = PTR_ERR(secs_epc_page);
 			secs_epc_page = NULL;


### PR DESCRIPTION
…ges, results in EPC memory exhausted and a dead loop in function sgx_alloc_page.
If terminate the enclave loading process forcedly, driver can't get back to normal work, other enclave loading will fail too.
So add the SGX_ENCL_DEAD flag checking in function sgx_alloc_page to fix this bug.