### PR TITLE
[V2] sgx_main: add sanity check when enumerating EPC resource

### DIFF
--- a/sgx_main.c
+++ b/sgx_main.c
@@ -219,8 +219,6 @@ static int sgx_init_platform(void)
 				(u64) (ecx & 0xfffff000);
 			sgx_epc_banks[sgx_nr_epc_banks].end =
 				sgx_epc_banks[sgx_nr_epc_banks].start + size;
-			if (!sgx_epc_banks[sgx_nr_epc_banks].start)
-				return -ENODEV;
 			sgx_nr_epc_banks++;
 		} else {
 			break;


### PR DESCRIPTION
V2:
sgx_main: clean up the redundant check during enumerating EPC resources
    
The start physical address of a EPC bank should not be zero if sgx is enabled.

V1 commit header:
According to the definition, the validity of EPC section start address
and size is determined by the lower 4 bits returned by EAX.

Currently, only 0 and 1 are defined values for the lower 4 bits of EAX
and ECX. So we add the sanity check for them in order to discover a
-NODEV returned if the valid lower bits of EAX and/or ECX extebded in
future.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>