### PR TITLE
Prevent from multiple creations on ksgxswapd

### DIFF
--- a/sgx_page_cache.c
+++ b/sgx_page_cache.c
@@ -434,6 +434,9 @@ int sgx_page_cache_init(void)
 
 	sgx_nr_high_pages = 2 * sgx_nr_low_pages;
 
+	if (ksgxswapd_tsk)
+		return 0;
+
 	tmp = kthread_run(ksgxswapd, NULL, "ksgxswapd");
 	if (!IS_ERR(tmp))
 		ksgxswapd_tsk = tmp;


### PR DESCRIPTION
If there are multiple EPC banks enumerated, multiple ksgxswapd will
be instantiated. This is unexpected result.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>