### PR TITLE
Optimize sgx_measure eextend loop

### DIFF
--- a/sgx_encl.c
+++ b/sgx_encl.c
@@ -181,10 +181,10 @@ static int sgx_measure(struct sgx_epc_page *secs_page,
 	void *secs;
 	void *epc;
 	int ret = 0;
-	int i, j;
+	int i;
 
-	for (i = 0, j = 1; i < 0x1000 && !ret; i += 0x100, j <<= 1) {
-		if (!(j & mrmask))
+	for (i = 0; (mrmask != 0) && (i < 0x1000) && !ret; i += 0x100, mrmask >>= 1) {
+		if (!(mrmask & 0x1))
 			continue;
 
 		secs = sgx_get_page(secs_page);


### PR DESCRIPTION
Many large enclaves have small eextend-able data but relatively large eadd-able data. Example includes large databases with relatively small Code/Data segments, but relatively large uninitialized heap. Loading such enclaves are currently extremely expense, and even though eadd and eextend are happening through a workque, it's useful to optimize the sgx_measure loop.

This change avoids unnecessary extend counter updates if the page doesn't need to be eextended.