### PR TITLE
intel_sgx: use mmu_notifier_unregister w/o "no_release"

### DIFF
--- a/sgx_encl.c
+++ b/sgx_encl.c
@@ -955,8 +955,7 @@ void sgx_encl_release(struct kref *ref)
 	mutex_unlock(&sgx_tgid_ctx_mutex);
 
 	if (encl->mmu_notifier.ops)
-		mmu_notifier_unregister_no_release(&encl->mmu_notifier,
-						   encl->mm);
+		mmu_notifier_unregister(&encl->mmu_notifier, encl->mm);
 
 	radix_tree_for_each_slot(slot, &encl->page_tree, &iter, 0) {
 		entry = *slot;


### PR DESCRIPTION
Replace the call to mmu_notifier_unregister_no_release() with a call
to the basic mmu_notifier_unregister().  The no_release variant was
not added until kernel 3.17 and using it prevents building the driver
in Debian 8 (and earlier).

Back when usge of the MMU notifier was added to the SGX driver, the
MMU release callback, sgx_mmu_notifier_release(), included acquiring
mmap_sem for read, i.e. down_read(&mm->mmap_sem).  This caused a
deadlock if we called mmu_notifier_unregister() in sgx_encl_release()
because the semaphore is already write-locked by munmap().  Eventually
we stopped acquiring mmap_sem in sgx_mmu_notifier_release(), but kept
using the no_release unregister variant as invoking release on a dying
enclave was unnecessary and added an extra lock/unlock sequence.

TL;DR: Calling mmu_notifier_unregister_no_release() was necessary to
avoid deadlock in an old incarnation of the driver, but the current
driver plays nice with the release variant.

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>