### PR TITLE
vm_insert_pfn replaced by vmf_insert_pfn from kernel 4.20

### DIFF
--- a/sgx_encl.c
+++ b/sgx_encl.c
@@ -250,7 +250,11 @@ static bool sgx_process_add_page_req(struct sgx_add_page_req *req,
 		return false;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0))
+	ret = vmf_insert_pfn(vma, encl_page->addr, PFN_DOWN(epc_page->pa));
+#else
 	ret = vm_insert_pfn(vma, encl_page->addr, PFN_DOWN(epc_page->pa));
+#endif
 	if (ret) {
 		sgx_put_backing(backing, 0);
 		return false;

--- a/sgx_util.c
+++ b/sgx_util.c
@@ -309,7 +309,11 @@ static struct sgx_encl_page *sgx_do_fault(struct vm_area_struct *vma,
 	epc_page = NULL;
 	list_add_tail(&entry->epc_page->list, &encl->load_list);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0))
+	rc = vmf_insert_pfn(vma, entry->addr, PFN_DOWN(entry->epc_page->pa));
+#else
 	rc = vm_insert_pfn(vma, entry->addr, PFN_DOWN(entry->epc_page->pa));
+#endif
 	if (rc) {
 		/* Kill the enclave if vm_insert_pfn fails; failure only occurs
 		 * if there is a driver bug or an unrecoverable issue, e.g. OOM.


### PR DESCRIPTION
Signed-off-by: Serge Ayoun <serge.ayoun@intel.com>