### PR TITLE
Enclave virtual address range should never be defined as MAP_PRIVATE.

### DIFF
--- a/sgx_main.c
+++ b/sgx_main.c
@@ -64,6 +64,7 @@
 #include <linux/file.h>
 #include <linux/highmem.h>
 #include <linux/miscdevice.h>
+#include <linux/mman.h>
 #include <linux/module.h>
 #include <linux/suspend.h>
 #include <linux/hashtable.h>
@@ -119,7 +120,7 @@ static unsigned long sgx_get_unmapped_area(struct file *file,
 					   unsigned long pgoff,
 					   unsigned long flags)
 {
-	if (len < 2 * PAGE_SIZE || (len & (len - 1)))
+	if (len < 2 * PAGE_SIZE || (len & (len - 1)) || flags & MAP_PRIVATE)
 		return -EINVAL;
 
 	/* On 64-bit architecture, allow mmap() to exceed 32-bit encl


### PR DESCRIPTION
Signed-off-by: Serge Ayoun <serge.ayoun@intel.com>