### PR TITLE
Kernel 4.20 and later: vmf_insert_pfn returns VM_FAULT_NOPAGE

### DIFF
--- a/sgx_encl.c
+++ b/sgx_encl.c
@@ -252,10 +252,11 @@ static bool sgx_process_add_page_req(struct sgx_add_page_req *req,
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0))
 	ret = vmf_insert_pfn(vma, encl_page->addr, PFN_DOWN(epc_page->pa));
+	if (ret != VM_FAULT_NOPAGE) {
 #else
 	ret = vm_insert_pfn(vma, encl_page->addr, PFN_DOWN(epc_page->pa));
-#endif
 	if (ret) {
+#endif
 		sgx_put_backing(backing, 0);
 		return false;
 	}

--- a/sgx_util.c
+++ b/sgx_util.c
@@ -311,10 +311,11 @@ static struct sgx_encl_page *sgx_do_fault(struct vm_area_struct *vma,
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0))
 	rc = vmf_insert_pfn(vma, entry->addr, PFN_DOWN(entry->epc_page->pa));
+	if (rc != VM_FAULT_NOPAGE) {
 #else
 	rc = vm_insert_pfn(vma, entry->addr, PFN_DOWN(entry->epc_page->pa));
-#endif
 	if (rc) {
+#endif
 		/* Kill the enclave if vm_insert_pfn fails; failure only occurs
 		 * if there is a driver bug or an unrecoverable issue, e.g. OOM.
 		 */


### PR DESCRIPTION
in success case

Signed-off-by: Serge Ayoun <serge.ayoun@intel.com>