### PR TITLE
sgx_vma: return unsigned int from sgx_vma_fault

### DIFF
--- a/sgx_vma.c
+++ b/sgx_vma.c
@@ -96,7 +96,11 @@ static void sgx_vma_close(struct vm_area_struct *vma)
 	kref_put(&encl->refcount, sgx_encl_release);
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0))
+static unsigned int sgx_vma_fault(struct vm_fault *vmf)
+{
+	struct vm_area_struct *vma = vmf->vma;
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))
 static int sgx_vma_fault(struct vm_fault *vmf)
 {
 	struct vm_area_struct *vma = vmf->vma;


### PR DESCRIPTION
For kernel v5.1.x, compiling the out-of-tree 'isgx' driver led to the
following error:
sgx_vma.c:241:11: error: initialization of 'vm_fault_t (*)(struct
vm_fault *)' {aka 'unsigned int (*)(struct vm_fault *)'} from
incompatible pointer type 'int (*)(struct vm_fault *)'
[-Werror=incompatible-pointer-types]

Hence, added return type of unsigned int to sgx_vma_fault for kernel
v5.1.

Signed-off-by: Iyer, Naveen <naveen.iyer@intel.com>