### PR TITLE
Fix incorrect entry return on sgx_do_fault

### DIFF
--- a/sgx_util.c
+++ b/sgx_util.c
@@ -324,6 +324,7 @@ static struct sgx_encl_page *sgx_do_fault(struct vm_area_struct *vma,
 		goto out;
 	}
 
+	rc = 0; /* reset rc on success (could be set to VM_FAULT_NOPAGE) */
 	sgx_test_and_clear_young(entry, encl);
 out:
 	mutex_unlock(&encl->lock);


### PR DESCRIPTION
Linux version 4.20+ returns VM_FAULT_NOPAGE on vmf_insert_pfn() which leads to sgx_do_fault() incorrectly treating this value as an error and propagating it as an address to other functions.

In particular, this bug leads to sgx_vma_access_word() working on a meaningless encl_page which ends in a kernel oops (due to incorrect memory access).

This commit overwrites return value from VM_FAULT_NOPAGE to zero on happy path in sgx_do_fault().

This bug was detected on Ubuntu 18.04 with Linux 5.1 while running any Graphene-SGX application under sgx-gdb. The bug manifested itself as a meaningless value returned from `sgx_vma_access()` after seemingly successful `sgx_fault_page()`. The returned value `entry = 256` (this is the value of VM_FAULT_NOPAGE) and led to a kernel oops in subsequent `sgx_vma_access_word()` on an incorrect kernel-memory dereference `encl_page->flags` (see `sgx_vma.c:147`). I was *not* able to reproduce this bug on Intel SGX SDK, with or without sgx-gdb.