### PR TITLE
README file updated: master branch (SGX 1.5) not supported anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ The Linux SGX software stack is comprised of the Intel(R) SGX driver, the Intel(
 The [linux-sgx-driver](https://github.com/01org/linux-sgx-driver) project hosts the out-of-tree driver for the Linux Intel(R) SGX software stack, which will be used until the driver upstreaming process is complete. 
 
 Within the linux-sgx-driver project, two versions of the out-of-tree driver are provided. Both versions are compatible with the linux-sgx PSW and SDK:
-- SGX 2.0 Linux Driver (sgx2)
+- SGX 2.0 Linux Driver (sgx2 branch)
   * The sgx2 branch of the linux-sgx-driver project contains the SGX 2.0 Linux Driver. This driver has additional support for SGX 2.0-based features available in upcoming CPUs. This driver has the same behavior as the SGX 1.5 Linux Driver (master) on CPUs without SGX 2.0 support.
-- SGX 1.5 Linux Driver (master)
+- SGX 1.5 Linux Driver (master branch)
   * The master branch of the linux-sgx-driver project tracks the proposed upstream version of the SGX 1.5 driver and does not yet support SGX 2.0-based features.
 
+IMPORTANT:
+---------
+Starting from 5/10/2019, the master branch (which supports only SGX 1.5-based features) is deprecated and is not supported anymore. Please use the sgx2 branch; it is a super set of the master branch.
 
 License
 -------


### PR DESCRIPTION
Branch sgx2 (SGX 1.5 and SGX 2.0) should be used from now.

Signed-off-by: Serge Ayoun <serge.ayoun@intel.com>