### PR TITLE
elfutils-libelf-devel is a prerequisite for RedHat 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Build and Install the Intel(R) SGX Driver
   * Ubuntu* 16.04.3 LTS Desktop 64bits
   * Ubuntu* 16.04.3 LTS Server 64bits
   * Red Hat Enterprise Linux Server release 7.4 64bits
+  * Red Hat Enterprise Linux Server release 8.0 64bits
   * CentOS 7.4.1708 64bits
   * SUSE Linux Enterprise Server 12 64bits
 - Ensure that you have the following required hardware:  
@@ -73,6 +74,10 @@ Build and Install the Intel(R) SGX Driver
         ```
         $ sudo yum install kernel
         $ sudo reboot
+        ```
+     * On RHEL 8.0 elfutils-libelf-devel package is required:
+        ```
+        $ sudo yum install elfutils-libelf-devel
         ```
 
 


### PR DESCRIPTION
README file updated

Signed-off-by: Serge Ayoun <serge.ayoun@intel.com>