### PR TITLE
Kernel 5.3.0 and later build error fix

### DIFF
--- a/sgx_page_cache.c
+++ b/sgx_page_cache.c
@@ -86,8 +86,11 @@ static unsigned int sgx_nr_high_pages;
 static struct task_struct *ksgxswapd_tsk;
 static DECLARE_WAIT_QUEUE_HEAD(ksgxswapd_waitq);
 
-static int sgx_test_and_clear_young_cb(pte_t *ptep, pgtable_t token,
-				       unsigned long addr, void *data)
+static int sgx_test_and_clear_young_cb(pte_t *ptep,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0))
+		pgtable_t token,
+#endif
+		unsigned long addr, void *data)
 {
 	pte_t pte;
 	int ret;


### PR DESCRIPTION
apply_to_page_range() interface change from kernel 5.3.0

Signed-off-by: Ayoun Serge <serge.ayoun@intel.com>