### PR TITLE
Kernel 5.3.0 and later: update to use new pte_fn_t

### DIFF
--- a/sgx_page_cache.c
+++ b/sgx_page_cache.c
@@ -86,8 +86,13 @@ static unsigned int sgx_nr_high_pages;
 static struct task_struct *ksgxswapd_tsk;
 static DECLARE_WAIT_QUEUE_HEAD(ksgxswapd_waitq);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0))
+static int sgx_test_and_clear_young_cb(pte_t *ptep, unsigned long addr,
+                       void *data)
+#else
 static int sgx_test_and_clear_young_cb(pte_t *ptep, pgtable_t token,
 				       unsigned long addr, void *data)
+#endif
 {
 	pte_t pte;
 	int ret;


### PR DESCRIPTION
Add compatibility to Kernel 5.3.0 and later.