### PR TITLE
Kernel 5.3.0 and later: use KBUILD_EXTMOD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ KDIR := /lib/modules/$(shell uname -r)/build
 PWD  := $(shell pwd)
 
 default:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) KBUILD_EXTMOD=$(PWD) modules
 
 install: default
 	$(MAKE) INSTALL_MOD_DIR=kernel/drivers/intel/sgx -C $(KDIR) M=$(PWD) modules_install


### PR DESCRIPTION
The KBUILD_EXTMOD is available since Kernel v2.6.x, so it will not break backward compatibility. 

- the SUBDIRS env is deprecated and will be removed soon
- using KBUILD_EXTMOD instead

Signed-off-by: Fábio Silva <fabio.fernando.osilva@gmail.com>