### PR TITLE
Build error fixes for kernel 5.3 and later

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ KDIR := /lib/modules/$(shell uname -r)/build
 PWD  := $(shell pwd)
 
 default:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
 install: default
 	$(MAKE) INSTALL_MOD_DIR=kernel/drivers/intel/sgx -C $(KDIR) M=$(PWD) modules_install

--- a/sgx_page_cache.c
+++ b/sgx_page_cache.c
@@ -86,8 +86,11 @@ static unsigned int sgx_nr_high_pages;
 static struct task_struct *ksgxswapd_tsk;
 static DECLARE_WAIT_QUEUE_HEAD(ksgxswapd_waitq);
 
-static int sgx_test_and_clear_young_cb(pte_t *ptep, pgtable_t token,
-				       unsigned long addr, void *data)
+static int sgx_test_and_clear_young_cb(pte_t *ptep,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0))
+		pgtable_t token,
+#endif
+		unsigned long addr, void *data)
 {
 	pte_t pte;
 	int ret;


### PR DESCRIPTION
apply_to_page_range() API signature was changed
Makefile does not support SUBDIR anymore

Signed-off-by: Ayoun Serge <serge.ayoun@intel.com>