### PR TITLE
Add SGX monitoring to driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,29 @@ $ sudo rm -rf "/lib/modules/"`uname -r`"/kernel/drivers/intel/sgx"
 $ sudo /sbin/depmod
 $ sudo /bin/sed -i '/^isgx$/d' /etc/modules
 ```
+
+Statistics and Monitoring
+-------------------------
+
+Usage statistics are available in /proc/sgx_enclaves and /proc/sgx_stats.
+sgx_enclaves provides a list of all of the enclaves currently configured
+on the system.  sgx_stats provides statistics about system usage.
+
+sgx_enclaves columns, in order:
+* pid/tgid of controlling process
+* ID of enclave (these are monotonically increasing)
+* max size of enclave from SECS
+* pages added to the enclave (not necessarily resident)
+* pages resident
+
+sgx_stats columns, in order:
+* number of enclaves created
+* number of enclaves removed (column 1 - column 2 is the number of
+  enclaves running)
+* total pages added to by removed enclaves (current info available
+  from sgx_enclaves)
+* total pages swapped into enclaves (including adds)
+* total pages swapped out/removed of enclaves
+* total size of enclave in 4K pages
+* number of pages used for va swap space
+* number of pages free (column 6 - column 7 - column 8 is pages in use)

--- a/sgx.h
+++ b/sgx.h
@@ -140,6 +140,7 @@ enum sgx_encl_flags {
 
 struct sgx_encl {
 	unsigned int flags;
+	unsigned int id;
 	uint64_t attributes;
 	uint64_t xfrm;
 	unsigned int secs_child_cnt;
@@ -152,6 +153,7 @@ struct sgx_encl {
 	unsigned long base;
 	unsigned long size;
 	unsigned long ssaframesize;
+	unsigned long eadd_cnt;  /* XXX: what about removals? */
 	struct list_head va_pages;
 	struct radix_tree_root page_tree;
 	struct list_head add_page_reqs;
@@ -159,6 +161,7 @@ struct sgx_encl {
 	struct sgx_encl_page secs;
 	struct sgx_tgid_ctx *tgid_ctx;
 	struct list_head encl_list;
+	struct list_head all_list;
 	struct mmu_notifier mmu_notifier;
 };
 
@@ -178,6 +181,11 @@ extern u64 sgx_encl_size_max_64;
 extern u64 sgx_xfrm_mask;
 extern u32 sgx_misc_reserved;
 extern u32 sgx_xsave_size_tbl[64];
+
+/* stats */
+extern unsigned int sgx_encl_created;
+extern unsigned int sgx_encl_released;
+extern long unsigned sgx_retired_eadd_cnt;
 
 extern const struct vm_operations_struct sgx_vm_ops;
 
@@ -239,6 +247,7 @@ struct sgx_encl_page *sgx_fault_page(struct vm_area_struct *vma,
 
 extern struct mutex sgx_tgid_ctx_mutex;
 extern struct list_head sgx_tgid_ctx_list;
+extern struct list_head sgx_all_encl_list;
 extern atomic_t sgx_va_pages_cnt;
 
 int sgx_add_epc_bank(resource_size_t start, unsigned long size, int bank);
@@ -250,5 +259,10 @@ void *sgx_get_page(struct sgx_epc_page *entry);
 void sgx_put_page(void *epc_page_vaddr);
 void sgx_eblock(struct sgx_encl *encl, struct sgx_epc_page *epc_page);
 void sgx_etrack(struct sgx_encl *encl);
+int sgx_stats_read(struct seq_file *file, void *v);
+void *sgx_encl_seq_start(struct seq_file *seq, loff_t *pos);
+void *sgx_encl_seq_next(struct seq_file *seq, void *v, loff_t *pos);
+void sgx_encl_seq_stop(struct seq_file *seq, void *v);
+int sgx_encl_seq_show(struct seq_file *file, void *v);
 
 #endif /* __ARCH_X86_INTEL_SGX_H__ */


### PR DESCRIPTION
This prototype code adds /proc/sgx_stats and /proc/sgx_enclaves files to
allow users to monitor SGX enclaves and paging activity.  If you want
to develop or deploy SGX applications, it is useful to know what the
system is doing.

These are based off of the sgx_driver_2.5 tag, as that's what we've
tested against.

sgxtop/sgxstat utilities to use this information are available at
https://github.com/fortanix/sgxtop

Signed-off-by: Kevin Lahey <kevin.lahey@fortanix.com>