### PR TITLE
Rename MSR_IA32_FEATURE_CONTROL and FEATURE_CONTROL_LOCKED

### DIFF
--- a/sgx_main.c
+++ b/sgx_main.c
@@ -74,6 +74,14 @@
 #define DRV_DESCRIPTION "Intel SGX Driver"
 #define DRV_VERSION "2.6.0"
 
+#ifndef MSR_IA32_FEAT_CTL
+#define MSR_IA32_FEAT_CTL MSR_IA32_FEATURE_CONTROL
+#endif
+
+#ifndef FEAT_CTL_LOCKED
+#define FEAT_CTL_LOCKED FEATURE_CONTROL_LOCKED
+#endif
+
 MODULE_DESCRIPTION(DRV_DESCRIPTION);
 MODULE_AUTHOR("Jarkko Sakkinen <jarkko.sakkinen@linux.intel.com>");
 MODULE_VERSION(DRV_VERSION);
@@ -81,7 +89,7 @@ MODULE_VERSION(DRV_VERSION);
 	#define X86_FEATURE_SGX (9 * 32 + 2)
 #endif
 
-#define FEATURE_CONTROL_SGX_ENABLE                      (1<<18)
+#define FEAT_CTL_SGX_ENABLED                      (1<<18)
 
 /*
  * Global data.
@@ -303,14 +311,14 @@ static int sgx_drv_probe(struct platform_device *pdev)
 		return -ENODEV;
 	}
 
-	rdmsrl(MSR_IA32_FEATURE_CONTROL, fc);
+	rdmsrl(MSR_IA32_FEAT_CTL, fc);
 
-	if (!(fc & FEATURE_CONTROL_LOCKED)) {
+	if (!(fc & FEAT_CTL_LOCKED)) {
 		pr_err("intel_sgx: the feature control MSR is not locked\n");
 		return -ENODEV;
 	}
 
-	if (!(fc & FEATURE_CONTROL_SGX_ENABLE)) {
+	if (!(fc & FEAT_CTL_SGX_ENABLED)) {
 		pr_err("intel_sgx: SGX is not enabled\n");
 		return -ENODEV;
 	}


### PR DESCRIPTION
They have new names in more recent kernels. We check for the old
defines, however, in order to prevent breaking on older kernels.

Also, rename FEATURE_CONTROL_SGX_ENABLE to match the new naming.