### PR TITLE
make get_unmapped_area() honer MAP_FIXED

### DIFF
--- a/sgx_main.c
+++ b/sgx_main.c
@@ -148,6 +148,9 @@ static unsigned long sgx_get_unmapped_area(struct file *file,
 		return -EINVAL;
 #endif
 
+	if (flags & MAP_FIXED)
+		return addr;
+
 	addr = current->mm->get_unmapped_area(file, addr, 2 * len, pgoff,
 					      flags);
 	if (IS_ERR_VALUE(addr))


### PR DESCRIPTION
When MAP_FIXED is passed to mmap(), honer the address instead of
calling mm->get_unampped_area().
Otherwise application requests enclave starting from 0 address,
it may fail if vm.mmap_min_addr > 0 which is usually true.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

fixes #113  