### PR TITLE
Fix compilation on 5.8 kernel

### DIFF
--- a/sgx_encl.c
+++ b/sgx_encl.c
@@ -332,7 +332,7 @@ static void sgx_add_page_worker(struct work_struct *work)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0))
 		mmap_read_unlock(encl->mm);
 #else
- 		up_read(&encl->mm->mmap_sem);
+		up_read(&encl->mm->mmap_sem);
 #endif
 
 next:

--- a/sgx_ioctl.c
+++ b/sgx_ioctl.c
@@ -78,11 +78,18 @@ int sgx_get_encl(unsigned long addr, struct sgx_encl **encl)
 	struct mm_struct *mm = current->mm;
 	struct vm_area_struct *vma;
 	int ret;
+	struct rw_semaphore *sem;
 
 	if (addr & (PAGE_SIZE - 1))
 		return -EINVAL;
 
-	down_read(&mm->mmap_sem);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0))
+	sem = &mm->mmap_lock;
+#else
+	sem = &mm->mmap_sem;
+#endif
+
+	down_read(sem);
 
 	ret = sgx_encl_find(mm, addr, &vma);
 	if (!ret) {
@@ -94,7 +101,7 @@ int sgx_get_encl(unsigned long addr, struct sgx_encl **encl)
 			kref_get(&(*encl)->refcount);
 	}
 
-	up_read(&mm->mmap_sem);
+	up_read(sem);
 	return ret;
 }
 

--- a/sgx_page_cache.c
+++ b/sgx_page_cache.c
@@ -1,4 +1,4 @@
- /*
+/*
  * This file is provided under a dual BSD/GPLv2 license.  When using or
  * redistributing this file, you may do so under either license.
  *


### PR DESCRIPTION
In the 5.8 rc kernels, the mm_struct's mmap_sem is renamed to mmap_lock.  Add pre-processor macros to select the appropriate field name on newer kernels.

Signed-off-by: Don Porter <porter@cs.unc.edu>