### PR TITLE
Support initializing enclaves without a launch token

### DIFF
--- a/sgx.h
+++ b/sgx.h
@@ -226,7 +226,7 @@ int sgx_encl_create(struct sgx_secs *secs);
 int sgx_encl_add_page(struct sgx_encl *encl, unsigned long addr, void *data,
 		      struct sgx_secinfo *secinfo, unsigned int mrmask);
 int sgx_encl_init(struct sgx_encl *encl, struct sgx_sigstruct *sigstruct,
-		  struct sgx_einittoken *einittoken);
+		  struct sgx_einittoken *einittoken, bool use_flc);
 struct sgx_encl_page *sgx_encl_augment(struct vm_area_struct *vma,
 				       unsigned long addr, bool write);
 void sgx_encl_release(struct kref *ref);
@@ -282,4 +282,6 @@ long modify_range(struct sgx_range *rg, unsigned long flags);
 int remove_page(struct sgx_encl *encl, unsigned long address, bool trim);
 int sgx_get_encl(unsigned long addr, struct sgx_encl **encl);
 int sgx_vm_insert_pfn(struct vm_area_struct *vma, unsigned long addr,  resource_size_t pa);
+
+void sgx_reset_pubkey_hash(void *failed);
 #endif /* __ARCH_X86_INTEL_SGX_H__ */

--- a/sgx_user.h
+++ b/sgx_user.h
@@ -69,6 +69,8 @@
 	_IOW(SGX_MAGIC, 0x01, struct sgx_enclave_add_page)
 #define SGX_IOC_ENCLAVE_INIT \
 	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init)
+#define SGX_IOC_ENCLAVE_INIT_NO_TOKEN \
+	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init_no_token)
 #define SGX_IOC_ENCLAVE_EMODPR \
 	_IOW(SGX_MAGIC, 0x09, struct sgx_modification_param)
 #define SGX_IOC_ENCLAVE_MKTCS \
@@ -145,6 +147,17 @@ struct sgx_enclave_init {
 	__u64	addr;
 	__u64	sigstruct;
 	__u64	einittoken;
+} __attribute__((__packed__));
+
+/**
+ * struct sgx_enclave_init - parameter structure for the
+ *                           %SGX_IOC_ENCLAVE_INIT ioctl
+ * @addr:	address in the ELRANGE
+ * @sigstruct:	address for the page data
+ */
+struct sgx_enclave_init_no_token {
+	__u64	addr;
+	__u64	sigstruct;
 } __attribute__((__packed__));
 
 /*


### PR DESCRIPTION
This is to create a driver that supports both SGX2 and launching QE3 with the PROVISION bit set.

Load the driver with `devsgx=y` to make AESMD use the right code paths.