### PR TITLE
Adapting modifications for the kernel.

### DIFF
--- a/sgx_main.c
+++ b/sgx_main.c
@@ -109,8 +109,8 @@ bool sgx_has_sgx2;
 static int sgx_mmap(struct file *file, struct vm_area_struct *vma)
 {
 	vma->vm_ops = &sgx_vm_ops;
-	vma->vm_flags |= VM_PFNMAP | VM_DONTEXPAND | VM_DONTDUMP | VM_IO |
-			 VM_DONTCOPY;
+	vm_flags_set(vma, VM_PFNMAP | VM_DONTEXPAND | VM_DONTDUMP | VM_IO |
+                    VM_DONTCOPY);
 
 	return 0;
 }


### PR DESCRIPTION
#152 
The kernel has set the vm_flags variable as const and provided a series of interfaces to manipulate it. Therefore, it is necessary to make appropriate modifications to the code in linux-sgx-driver. 